### PR TITLE
Remove mirror input on DjangoFormMutation#1

### DIFF
--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -151,4 +151,3 @@ class DjangoConnectionField(ConnectionField):
             self.max_limit,
             self.enforce_first_or_last,
         )
-

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -151,3 +151,4 @@ class DjangoConnectionField(ConnectionField):
             self.max_limit,
             self.enforce_first_or_last,
         )
+

--- a/graphene_django/forms/mutation.py
+++ b/graphene_django/forms/mutation.py
@@ -103,7 +103,7 @@ class DjangoFormMutation(BaseDjangoFormMutation):
 
     @classmethod
     def __init_subclass_with_meta__(
-        cls, form_class=None, only_fields=(), exclude_fields=(), **options
+        cls, form_class=None, mirror_input=False, only_fields=(), exclude_fields=(), **options
     ):
 
         if not form_class:
@@ -111,7 +111,10 @@ class DjangoFormMutation(BaseDjangoFormMutation):
 
         form = form_class()
         input_fields = fields_for_form(form, only_fields, exclude_fields)
-        output_fields = fields_for_form(form, only_fields, exclude_fields)
+        if mirror_input:
+            output_fields = fields_for_form(form, only_fields, exclude_fields)
+        else:
+            output_fields = {}
 
         _meta = DjangoFormMutationOptions(cls)
         _meta.form_class = form_class

--- a/graphene_django/forms/tests/test_mutation.py
+++ b/graphene_django/forms/tests/test_mutation.py
@@ -139,3 +139,36 @@ class ModelFormMutationTests(TestCase):
         self.assertEqual(result.errors[0].messages, ["This field is required."])
         self.assertIn("age", fields_w_error)
         self.assertEqual(result.errors[1].messages, ["This field is required."])
+
+
+class FormMutationTests(TestCase):
+    def test_default_meta_fields(self):
+        class MyMutation(DjangoFormMutation):
+            class Meta:
+                form_class = MyForm
+        self.assertNotIn("text", MyMutation._meta.fields)
+
+    def test_mirror_meta_fields(self):
+        class MyMutation(DjangoFormMutation):
+            class Meta:
+                form_class = MyForm
+                mirror_input = True
+
+        self.assertIn("text", MyMutation._meta.fields)
+
+    def test_default_input_meta_fields(self):
+        class MyMutation(DjangoFormMutation):
+            class Meta:
+                form_class = MyForm
+
+        self.assertIn("client_mutation_id", MyMutation.Input._meta.fields)
+        self.assertIn("text", MyMutation.Input._meta.fields)
+
+    def test_exclude_fields_input_meta_fields(self):
+        class MyMutation(DjangoFormMutation):
+            class Meta:
+                form_class = MyForm
+                exclude_fields = ['text']
+
+        self.assertNotIn("text", MyMutation.Input._meta.fields)
+        self.assertIn("client_mutation_id", MyMutation.Input._meta.fields)


### PR DESCRIPTION
Los campos de entrada solo se duplican como campos de salida con la configuracion correcta en la metaclase (issue #1)
Por defecto, los campos de entrada no se duplican, solo si reciben un argumento `mirror_input = True` en la Metaclase, por ejemplo:

```python
        class MyMutation(DjangoFormMutation):
            class Meta:
                form_class = MyForm
                mirror_input = True
```