### PR TITLE
Permissions to fields#3

### DIFF
--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -157,13 +157,13 @@ class DjangoConnectionField(ConnectionField):
 class DjangoField(Field):
     """Class to manage permission for fields"""
 
-    def __init__(self, type, permissions, permission_resolver=auth_resolver, *args, **kwargs):
+    def __init__(self, type, permissions, permissions_resolver=auth_resolver, *args, **kwargs):
         """Get permissions to access a field"""
         super(DjangoField, self).__init__(type, *args, **kwargs)
         self.permissions = permissions
-        self.permissions_resolver = permission_resolver
+        self.permissions_resolver = permissions_resolver
 
     def get_resolver(self, parent_resolver):
         """Intercept resolver to analyse permissions"""
-        return partial(get_unbound_function(self.permission_resolver), self.resolver or parent_resolver,
+        return partial(get_unbound_function(self.permissions_resolver), self.resolver or parent_resolver,
                        self.permissions, raise_exception=True)

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -2,6 +2,7 @@ from functools import partial
 
 from django.core.exceptions import PermissionDenied
 from django.db.models.query import QuerySet
+from graphene.utils.get_unbound_function import get_unbound_function
 
 from promise import Promise
 
@@ -165,4 +166,5 @@ class DjangoPermissionField(Field):
 
     def get_resolver(self, parent_resolver):
         """Intercept resolver to analyse permissions"""
-        return partial(self.AUTH_RESOLVER, self.resolver or parent_resolver, self.permissions, True)
+        return partial(get_unbound_function(self.AUTH_RESOLVER), self.resolver or parent_resolver, self.permissions,
+                       True)

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -157,7 +157,7 @@ class DjangoConnectionField(ConnectionField):
 class PermissionField(Field):
     """Class to manage permission for fields"""
 
-    def __init__(self, type, permissions, permissions_resolver=auth_resolver, *args, **kwargs):
+    def __init__(self, type, permissions=(), permissions_resolver=auth_resolver, *args, **kwargs):
         """Get permissions to access a field"""
         super(PermissionField, self).__init__(type, *args, **kwargs)
         self.permissions = permissions
@@ -165,5 +165,7 @@ class PermissionField(Field):
 
     def get_resolver(self, parent_resolver):
         """Intercept resolver to analyse permissions"""
-        return partial(get_unbound_function(self.permissions_resolver), self.resolver or parent_resolver,
-                       self.permissions, True)
+        parent_resolver = super(PermissionField, self).get_resolver(parent_resolver)
+        if self.permissions:
+            return partial(get_unbound_function(self.permissions_resolver), parent_resolver, self.permissions, True)
+        return parent_resolver

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -156,6 +156,7 @@ class DjangoConnectionField(ConnectionField):
 
 class DjangoPermissionField(Field):
     """Class to manage permission for fields"""
+    AUTH_RESOLVER = auth_resolver
 
     def __init__(self, type, permissions, *args, **kwargs):
         """Get permissions to access a field"""
@@ -164,4 +165,4 @@ class DjangoPermissionField(Field):
 
     def get_resolver(self, parent_resolver):
         """Intercept resolver to analyse permissions"""
-        return partial(auth_resolver, self.resolver or parent_resolver, self.permissions, True)
+        return partial(self.AUTH_RESOLVER, self.resolver or parent_resolver, self.permissions, True)

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -1,5 +1,6 @@
 from functools import partial
 
+from django.core.exceptions import PermissionDenied
 from django.db.models.query import QuerySet
 
 from promise import Promise
@@ -9,7 +10,7 @@ from graphene.relay import ConnectionField, PageInfo
 from graphql_relay.connection.arrayconnection import connection_from_list_slice
 
 from .settings import graphene_settings
-from .utils import maybe_queryset
+from .utils import maybe_queryset, has_permissions, resolve_bound_resolver
 
 
 class DjangoListField(Field):
@@ -151,3 +152,37 @@ class DjangoConnectionField(ConnectionField):
             self.max_limit,
             self.enforce_first_or_last,
         )
+
+
+class DjangoPermissionField(Field):
+    """Class to manage permission for fields"""
+
+    def __init__(self, type, permissions, *args, **kwargs):
+        """Get permissions to access a field"""
+        super(DjangoPermissionField, self).__init__(type, *args, **kwargs)
+        self.permissions = permissions
+
+    def permission_resolver(self, parent_resolver, raise_exception, root, info, **args):
+        """
+        Middleware resolver to check viewer's permissions
+        :param parent_resolver: Field resolver
+        :param raise_exception: If True a PermissionDenied is raised
+        :param root: Schema root
+        :param info: Schema info
+        :param args: Schema args
+        :return: Resolved field. None if the viewer does not have permission to access the field.
+        """
+        # Get viewer from context
+        user = info.context.user
+        if has_permissions(user, self.permissions):
+            if parent_resolver:
+                # A resolver is provided in the class
+                return resolve_bound_resolver(parent_resolver, root, info, **args)
+            # Get default resolver
+        elif raise_exception:
+            raise PermissionDenied()
+        return None
+
+    def get_resolver(self, parent_resolver):
+        """Intercept resolver to analyse permissions"""
+        return partial(self.permission_resolver, parent_resolver, True)

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -1,8 +1,7 @@
 from functools import partial
 
-from django.core.exceptions import PermissionDenied
 from django.db.models.query import QuerySet
-from graphene.utils.get_unbound_function import get_unbound_function
+from django.utils.six import get_unbound_function
 
 from promise import Promise
 
@@ -155,16 +154,16 @@ class DjangoConnectionField(ConnectionField):
         )
 
 
-class DjangoPermissionField(Field):
+class DjangoField(Field):
     """Class to manage permission for fields"""
-    AUTH_RESOLVER = auth_resolver
 
-    def __init__(self, type, permissions, *args, **kwargs):
+    def __init__(self, type, permissions, permission_resolver=auth_resolver, *args, **kwargs):
         """Get permissions to access a field"""
-        super(DjangoPermissionField, self).__init__(type, *args, **kwargs)
+        super(DjangoField, self).__init__(type, *args, **kwargs)
         self.permissions = permissions
+        self.permissions_resolver = permission_resolver
 
     def get_resolver(self, parent_resolver):
         """Intercept resolver to analyse permissions"""
-        return partial(get_unbound_function(self.AUTH_RESOLVER), self.resolver or parent_resolver, self.permissions,
-                       True)
+        return partial(get_unbound_function(self.permission_resolver), self.resolver or parent_resolver,
+                       self.permissions, raise_exception=True)

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -162,6 +162,10 @@ class DjangoPermissionField(Field):
         super(DjangoPermissionField, self).__init__(type, *args, **kwargs)
         self.permissions = permissions
 
+    def get_viewer(self, root, info, **args):
+        """Get viewer to verify permissions"""
+        return info.context.user
+
     def permission_resolver(self, parent_resolver, raise_exception, root, info, **args):
         """
         Middleware resolver to check viewer's permissions
@@ -173,7 +177,7 @@ class DjangoPermissionField(Field):
         :return: Resolved field. None if the viewer does not have permission to access the field.
         """
         # Get viewer from context
-        user = info.context.user
+        user = self.get_viewer(root, info, **args)
         if has_permissions(user, self.permissions):
             if parent_resolver:
                 # A resolver is provided in the class

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -166,4 +166,4 @@ class DjangoField(Field):
     def get_resolver(self, parent_resolver):
         """Intercept resolver to analyse permissions"""
         return partial(get_unbound_function(self.permissions_resolver), self.resolver or parent_resolver,
-                       self.permissions, raise_exception=True)
+                       self.permissions, True)

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -154,12 +154,12 @@ class DjangoConnectionField(ConnectionField):
         )
 
 
-class DjangoField(Field):
+class PermissionField(Field):
     """Class to manage permission for fields"""
 
     def __init__(self, type, permissions, permissions_resolver=auth_resolver, *args, **kwargs):
         """Get permissions to access a field"""
-        super(DjangoField, self).__init__(type, *args, **kwargs)
+        super(PermissionField, self).__init__(type, *args, **kwargs)
         self.permissions = permissions
         self.permissions_resolver = permissions_resolver
 

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -1,12 +1,12 @@
 from functools import partial
 
 from django.db.models.query import QuerySet
-from django.utils.six import get_unbound_function
 
 from promise import Promise
 
 from graphene.types import Field, List
 from graphene.relay import ConnectionField, PageInfo
+from graphene.utils.get_unbound_function import get_unbound_function
 from graphql_relay.connection.arrayconnection import connection_from_list_slice
 
 from .settings import graphene_settings

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -1,8 +1,7 @@
 from functools import partial
 
-from django.core.exceptions import PermissionDenied
 from django.db.models.query import QuerySet
-from graphene.utils.get_unbound_function import get_unbound_function
+from django.utils.six import get_unbound_function
 
 from promise import Promise
 

--- a/graphene_django/tests/test_fields.py
+++ b/graphene_django/tests/test_fields.py
@@ -1,0 +1,46 @@
+from unittest import TestCase
+from django.core.exceptions import PermissionDenied
+from graphene_django.fields import DjangoPermissionField
+
+
+class MyInstance(object):
+    value = "value"
+
+    def resolver(self):
+        return "resolver method"
+
+
+class PermissionFieldTests(TestCase):
+
+    def test_permission_field(self):
+        MyType = object()
+        field = DjangoPermissionField(MyType, permissions=['perm1', 'perm2'], source='resolver')
+        resolver = field.get_resolver(field.resolver)
+
+        class Viewer(object):
+            def has_perm(self, perm):
+                return perm == 'perm2'
+
+        class Info(object):
+            class Context(object):
+                user = Viewer()
+            context = Context()
+
+        self.assertEqual(resolver(MyInstance(), Info()), MyInstance().resolver())
+
+    def test_permission_field_without_permission(self):
+        MyType = object()
+        field = DjangoPermissionField(MyType, permissions=['perm1', 'perm2'], source='resolver')
+        resolver = field.get_resolver(field.resolver)
+
+        class Viewer(object):
+            def has_perm(self, perm):
+                return False
+
+        class Info(object):
+            class Context(object):
+                user = Viewer()
+            context = Context()
+
+        with self.assertRaises(PermissionDenied):
+            resolver(MyInstance(), Info())

--- a/graphene_django/tests/test_fields.py
+++ b/graphene_django/tests/test_fields.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from django.core.exceptions import PermissionDenied
-from graphene_django.fields import DjangoPermissionField
+from graphene_django.fields import DjangoField
 
 
 class MyInstance(object):
@@ -14,7 +14,7 @@ class DjangoPermissionFieldTests(TestCase):
 
     def test_permission_field(self):
         MyType = object()
-        field = DjangoPermissionField(MyType, permissions=['perm1', 'perm2'], source='resolver')
+        field = DjangoField(MyType, permissions=['perm1', 'perm2'], source='resolver')
         resolver = field.get_resolver(None)
 
         class Viewer(object):
@@ -30,7 +30,7 @@ class DjangoPermissionFieldTests(TestCase):
 
     def test_permission_field_without_permission(self):
         MyType = object()
-        field = DjangoPermissionField(MyType, permissions=['perm1', 'perm2'], source='resolver')
+        field = DjangoField(MyType, permissions=['perm1', 'perm2'], source='resolver')
         resolver = field.get_resolver(field.resolver)
 
         class Viewer(object):

--- a/graphene_django/tests/test_fields.py
+++ b/graphene_django/tests/test_fields.py
@@ -15,7 +15,7 @@ class DjangoPermissionFieldTests(TestCase):
     def test_permission_field(self):
         MyType = object()
         field = DjangoPermissionField(MyType, permissions=['perm1', 'perm2'], source='resolver')
-        resolver = field.get_resolver(field.resolver)
+        resolver = field.get_resolver(None)
 
         class Viewer(object):
             def has_perm(self, perm):

--- a/graphene_django/tests/test_fields.py
+++ b/graphene_django/tests/test_fields.py
@@ -10,7 +10,7 @@ class MyInstance(object):
         return "resolver method"
 
 
-class PermissionFieldTests(TestCase):
+class DjangoPermissionFieldTests(TestCase):
 
     def test_permission_field(self):
         MyType = object()

--- a/graphene_django/tests/test_fields.py
+++ b/graphene_django/tests/test_fields.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from django.core.exceptions import PermissionDenied
-from graphene_django.fields import DjangoField
+from graphene_django.fields import PermissionField
 
 
 class MyInstance(object):
@@ -10,11 +10,11 @@ class MyInstance(object):
         return "resolver method"
 
 
-class DjangoPermissionFieldTests(TestCase):
+class PermissionFieldTests(TestCase):
 
     def test_permission_field(self):
         MyType = object()
-        field = DjangoField(MyType, permissions=['perm1', 'perm2'], source='resolver')
+        field = PermissionField(MyType, permissions=['perm1', 'perm2'], source='resolver')
         resolver = field.get_resolver(None)
 
         class Viewer(object):
@@ -30,7 +30,7 @@ class DjangoPermissionFieldTests(TestCase):
 
     def test_permission_field_without_permission(self):
         MyType = object()
-        field = DjangoField(MyType, permissions=['perm1', 'perm2'], source='resolver')
+        field = PermissionField(MyType, permissions=['perm1', 'perm2'], source='resolver')
         resolver = field.get_resolver(field.resolver)
 
         class Viewer(object):

--- a/graphene_django/tests/test_utils.py
+++ b/graphene_django/tests/test_utils.py
@@ -1,4 +1,4 @@
-from ..utils import get_model_fields
+from ..utils import get_model_fields, has_permissions
 from .models import Film, Reporter
 
 
@@ -10,3 +10,23 @@ def test_get_model_fields_no_duplication():
     film_fields = get_model_fields(Film)
     film_name_set = set([field[0] for field in film_fields])
     assert len(film_fields) == len(film_name_set)
+
+
+def test_has_permissions():
+    class Viewer(object):
+        @staticmethod
+        def has_perm(permission):
+            return permission
+
+    viewer_as_perm = has_permissions(Viewer(), [False, True, False])
+    assert viewer_as_perm
+
+
+def test_viewer_without_permissions():
+    class Viewer(object):
+        @staticmethod
+        def has_perm(permission):
+            return permission
+
+    viewer_as_perm = has_permissions(Viewer(), [False, False, False])
+    assert not viewer_as_perm

--- a/graphene_django/utils.py
+++ b/graphene_django/utils.py
@@ -5,7 +5,6 @@ from django.db.models.manager import Manager
 
 
 # from graphene.utils import LazyList
-from graphene.types.resolver import get_default_resolver
 from graphene.utils.get_unbound_function import get_unbound_function
 
 

--- a/graphene_django/utils.py
+++ b/graphene_django/utils.py
@@ -122,7 +122,10 @@ def auth_resolver(parent_resolver, permissions, raise_exception, root, info, **a
     :return: Resolved field. None if the viewer does not have permission to access the field.
     """
     # Get viewer from context
+    if not hasattr(info.context, 'user'):
+        raise PermissionDenied()
     user = info.context.user
+
     if has_permissions(user, permissions):
         if parent_resolver:
             # A resolver is provided in the class

--- a/graphene_django/utils.py
+++ b/graphene_django/utils.py
@@ -5,6 +5,8 @@ from django.db.models.manager import Manager
 
 
 # from graphene.utils import LazyList
+from graphene.types.resolver import get_default_resolver
+from graphene.utils.get_unbound_function import get_unbound_function
 
 
 class LazyList(object):
@@ -81,3 +83,28 @@ def import_single_dispatch():
         )
 
     return singledispatch
+
+
+def has_permissions(viewer, permissions):
+    """
+    Verify that at least one permission is accomplished
+    :param viewer: Field's viewer
+    :param permissions: Field permissions
+    :return: True if viewer has permission. False otherwise.
+    """
+    if not permissions:
+        return True
+    return any([viewer.has_perm(perm) for perm in permissions])
+
+
+def resolve_bound_resolver(resolver, root, info, **args):
+    """
+    Resolve provided resolver
+    :param resolver: Explicit field resolver
+    :param root: Schema root
+    :param info: Schema info
+    :param args: Schema args
+    :return: Resolved field
+    """
+    resolver = get_unbound_function(resolver)
+    return resolver(root, info, **args)


### PR DESCRIPTION
Creacion de un `DjangoPermissionField` (issue #3) que permite la verificacion de permisos antes de resolver un campo, evitando su resolucion en caso de que no se tengan los permisos pertinentes.