### PR TITLE
Permission to type#5

### DIFF
--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -165,4 +165,5 @@ class DjangoPermissionField(Field):
 
     def get_resolver(self, parent_resolver):
         """Intercept resolver to analyse permissions"""
-        return partial(get_unbound_function(self.AUTH_RESOLVER), self.resolver or parent_resolver, self.permissions,None, None, True)
+        return partial(get_unbound_function(self.AUTH_RESOLVER), self.resolver or parent_resolver, self.permissions,
+                       None, None, True)

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -165,4 +165,5 @@ class DjangoField(Field):
 
     def get_resolver(self, parent_resolver):
         """Intercept resolver to analyse permissions"""
-        return partial(get_unbound_function(self.permissions_resolver), self.resolver or parent_resolver, self.permissions,None, None, True)
+        return partial(get_unbound_function(self.permissions_resolver), self.resolver or parent_resolver,
+                       self.permissions, None, None, True)

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -154,18 +154,18 @@ class DjangoConnectionField(ConnectionField):
         )
 
 
-class PermissionField(Field):
+class DjangoField(Field):
     """Class to manage permission for fields"""
 
     def __init__(self, type, permissions=(), permissions_resolver=auth_resolver, *args, **kwargs):
         """Get permissions to access a field"""
-        super(PermissionField, self).__init__(type, *args, **kwargs)
+        super(DjangoField, self).__init__(type, *args, **kwargs)
         self.permissions = permissions
         self.permissions_resolver = permissions_resolver
 
     def get_resolver(self, parent_resolver):
         """Intercept resolver to analyse permissions"""
-        parent_resolver = super(PermissionField, self).get_resolver(parent_resolver)
+        parent_resolver = super(DjangoField, self).get_resolver(parent_resolver)
         if self.permissions:
             return partial(get_unbound_function(self.permissions_resolver), parent_resolver, self.permissions, None, None, True)
         return parent_resolver

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -164,4 +164,4 @@ class DjangoPermissionField(Field):
 
     def get_resolver(self, parent_resolver):
         """Intercept resolver to analyse permissions"""
-        return partial(auth_resolver, self.resolver or parent_resolver, self.permissions, True)
+        return partial(auth_resolver, self.resolver or parent_resolver, self.permissions, None, None, True)

--- a/graphene_django/tests/test_fields.py
+++ b/graphene_django/tests/test_fields.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from django.core.exceptions import PermissionDenied
-from graphene_django.fields import PermissionField
+from graphene_django.fields import DjangoField
 
 
 class MyInstance(object):
@@ -14,7 +14,7 @@ class PermissionFieldTests(TestCase):
 
     def test_permission_field(self):
         MyType = object()
-        field = PermissionField(MyType, permissions=['perm1', 'perm2'], source='resolver')
+        field = DjangoField(MyType, permissions=['perm1', 'perm2'], source='resolver')
         resolver = field.get_resolver(None)
 
         class Viewer(object):
@@ -30,7 +30,7 @@ class PermissionFieldTests(TestCase):
 
     def test_permission_field_without_permission(self):
         MyType = object()
-        field = PermissionField(MyType, permissions=['perm1', 'perm2'], source='resolver')
+        field = DjangoField(MyType, permissions=['perm1', 'perm2'], source='resolver')
         resolver = field.get_resolver(field.resolver)
 
         class Viewer(object):

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -257,7 +257,7 @@ def test_django_permissions():
         'reporter': ('content_type.permission3',),
         'extra_field': ('content_type.permission3',),
     }
-    assert PermissionArticle._meta.field_permissions == expected
+    assert PermissionArticle.field_permissions == expected
 
 
 def test_permission_resolver():

--- a/graphene_django/tests/test_types.py
+++ b/graphene_django/tests/test_types.py
@@ -4,7 +4,7 @@ from graphene import Interface, ObjectType, Schema, Connection, String, Field
 from graphene.relay import Node
 
 from .. import registry
-from ..types import DjangoObjectType, DjangoObjectTypeOptions, DjangoPermissionObjectType
+from ..types import DjangoObjectType, DjangoObjectTypeOptions
 from .models import Article as ArticleModel
 from .models import Reporter as ReporterModel
 
@@ -230,7 +230,7 @@ def extra_field_resolver(root, info, **kwargs):
     return 'extra field'
 
 
-class PermissionArticle(DjangoPermissionObjectType):
+class PermissionArticle(DjangoObjectType):
     """Basic Type to test"""
 
     class Meta(object):
@@ -257,7 +257,7 @@ def test_django_permissions():
         'reporter': ('content_type.permission3',),
         'extra_field': ('content_type.permission3',),
     }
-    assert PermissionArticle._field_permissions == expected
+    assert PermissionArticle._meta.field_permissions == expected
 
 
 def test_permission_resolver():

--- a/graphene_django/types.py
+++ b/graphene_django/types.py
@@ -175,7 +175,7 @@ class DjangoPermissionObjectType(DjangoObjectType):
             if not hasattr(field_permissions, '__iter__'):
                 field_permissions = tuple(field_permissions)
 
-            cls.set_auth_resolver(field_name, field_permissions, cls._meta.fields[field_name], resolver)
+            setattr(cls, attr, cls.set_auth_resolver(field_name, field_permissions, resolver))
 
         if cls._field_permissions:
             cls._set_as_nullable(model, registry)

--- a/graphene_django/types.py
+++ b/graphene_django/types.py
@@ -136,7 +136,7 @@ class DjangoObjectType(ObjectType):
 
         field_permissions = cls.__get_field_permissions__(field_to_permission, permission_to_field)
         if field_permissions:
-            cls.__set_as_nullable__(model, registry)
+            cls.__set_as_nullable__(field_permissions, model, registry)
 
         super(DjangoObjectType, cls).__init_subclass_with_meta__(
             _meta=_meta, interfaces=interfaces, **options
@@ -195,10 +195,10 @@ class DjangoObjectType(ObjectType):
             setattr(cls, attr, get_auth_resolver(field_name, field_permissions, resolver))
 
     @classmethod
-    def __set_as_nullable__(cls, model, registry):
+    def __set_as_nullable__(cls, field_permissions, model, registry):
         """Set restricted fields as nullable"""
         django_fields = yank_fields_from_attrs(
-            construct_fields(model, registry, cls.field_permissions.keys(), ()),
+            construct_fields(model, registry, field_permissions.keys(), ()),
             _as=Field,
         )
         for name, field in django_fields.items():

--- a/graphene_django/types.py
+++ b/graphene_django/types.py
@@ -127,6 +127,8 @@ class DjangoObjectType(ObjectType):
             _meta=_meta, interfaces=interfaces, **options
         )
 
+        cls.__set_permissions__(field_to_permission, permission_to_field)
+
         if cls.field_permissions:
             cls.__set_as_nullable__(cls._meta.model, cls._meta.registry)
 

--- a/graphene_django/types.py
+++ b/graphene_django/types.py
@@ -134,15 +134,18 @@ class DjangoObjectType(ObjectType):
         _meta.fields = django_fields
         _meta.connection = connection
 
+        field_permissions = cls.__get_field_permissions__(field_to_permission, permission_to_field)
+        if field_permissions:
+            cls.__set_as_nullable__(model, registry)
+
         super(DjangoObjectType, cls).__init_subclass_with_meta__(
             _meta=_meta, interfaces=interfaces, **options
         )
 
-        cls.field_permissions = cls.__get_field_permissions__(field_to_permission, permission_to_field)
+        if field_permissions:
+            cls.__set_permissions_resolvers__(field_permissions)
 
-        if cls.field_permissions:
-            cls.__set_permissions_resolvers__(cls.field_permissions)
-            cls.__set_as_nullable__(cls._meta.model, cls._meta.registry)
+        cls.field_permissions = field_permissions
 
         if not skip_registry:
             registry.register(cls)

--- a/graphene_django/types.py
+++ b/graphene_django/types.py
@@ -33,7 +33,7 @@ def construct_fields(model, registry, only_fields, exclude_fields):
     return fields
 
 
-def get_auth_resolver(cls, name, permissions, resolver=None):
+def get_auth_resolver(name, permissions, resolver=None):
     """
     Get middleware resolver to handle field permissions
     :param name: Field name

--- a/graphene_django/utils.py
+++ b/graphene_django/utils.py
@@ -6,8 +6,8 @@ from django.db.models.manager import Manager
 
 
 # from graphene.utils import LazyList
-from django.utils.six import get_unbound_function
 from graphene.types.resolver import get_default_resolver
+from graphene.utils.get_unbound_function import get_unbound_function
 
 
 class LazyList(object):

--- a/graphene_django/utils.py
+++ b/graphene_django/utils.py
@@ -6,6 +6,7 @@ from django.db.models.manager import Manager
 
 
 # from graphene.utils import LazyList
+from graphene.types.resolver import get_default_resolver
 from graphene.utils.get_unbound_function import get_unbound_function
 
 
@@ -110,11 +111,27 @@ def resolve_bound_resolver(resolver, root, info, **args):
     return resolver(root, info, **args)
 
 
-def auth_resolver(parent_resolver, permissions, raise_exception, root, info, **args):
+def resolve_default_resolver(attname, default_value, root, info, **args):
+    """
+    Resolve field with default resolver
+    :param attname: Field name
+    :param default_value: Field default value
+    :param root: Schema root
+    :param info: Schema info
+    :param args: Schema args
+    :return: Resolved field
+    """
+    resolver = get_default_resolver()
+    return resolver(attname, default_value, root, info, **args)
+
+
+def auth_resolver(parent_resolver, permissions, attname, default_value, raise_exception, root, info, **args):
     """
     Middleware resolver to check viewer's permissions
     :param parent_resolver: Field resolver
     :param permissions: Field permissions
+    :param attname: Field name
+    :param default_value: Default value to field if no resolver is provided
     :param raise_exception: If True a PermissionDenied is raised
     :param root: Schema root
     :param info: Schema info
@@ -127,6 +144,8 @@ def auth_resolver(parent_resolver, permissions, raise_exception, root, info, **a
         if parent_resolver:
             # A resolver is provided in the class
             return resolve_bound_resolver(parent_resolver, root, info, **args)
+        # Get default resolver
+        return resolve_default_resolver(attname, default_value, root, info, **args)
     elif raise_exception:
         raise PermissionDenied()
     return None

--- a/graphene_django/utils.py
+++ b/graphene_django/utils.py
@@ -131,7 +131,7 @@ def auth_resolver(parent_resolver, permissions, attname, default_value, raise_ex
             # A resolver is provided in the class
             return resolve_bound_resolver(parent_resolver, root, info, **args)
         # Get default resolver
-        return get_default_resolver(attname, default_value, root, info, **args)
+        return get_default_resolver()(attname, default_value, root, info, **args)
     elif raise_exception:
         raise PermissionDenied()
     return None

--- a/graphene_django/utils.py
+++ b/graphene_django/utils.py
@@ -6,8 +6,8 @@ from django.db.models.manager import Manager
 
 
 # from graphene.utils import LazyList
+from django.utils.six import get_unbound_function
 from graphene.types.resolver import get_default_resolver
-from graphene.utils.get_unbound_function import get_unbound_function
 
 
 class LazyList(object):
@@ -111,20 +111,6 @@ def resolve_bound_resolver(resolver, root, info, **args):
     return resolver(root, info, **args)
 
 
-def resolve_default_resolver(attname, default_value, root, info, **args):
-    """
-    Resolve field with default resolver
-    :param attname: Field name
-    :param default_value: Field default value
-    :param root: Schema root
-    :param info: Schema info
-    :param args: Schema args
-    :return: Resolved field
-    """
-    resolver = get_default_resolver()
-    return resolver(attname, default_value, root, info, **args)
-
-
 def auth_resolver(parent_resolver, permissions, attname, default_value, raise_exception, root, info, **args):
     """
     Middleware resolver to check viewer's permissions
@@ -145,7 +131,7 @@ def auth_resolver(parent_resolver, permissions, attname, default_value, raise_ex
             # A resolver is provided in the class
             return resolve_bound_resolver(parent_resolver, root, info, **args)
         # Get default resolver
-        return resolve_default_resolver(attname, default_value, root, info, **args)
+        return get_default_resolver(attname, default_value, root, info, **args)
     elif raise_exception:
         raise PermissionDenied()
     return None


### PR DESCRIPTION
Creacion de una DjangoPermissionObjectType para el manejo de permiso de los object types de graphene (issue #5 )
Se acepta en la Metaclase una definicion de aquellos campos que necesiten permisos especiales para acceder a ellos.
Se proveen dos formas de definir estas restricciones:
```python
class Meta:
    field_to_permission = {'field': ('permission1', 'permission2')}
    permission_to_field= {'permission1': ('field1', 'field2')}
```

Depende de #4 