### PR TITLE
Convert form choice#7

### DIFF
--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -167,5 +167,6 @@ class DjangoField(Field):
         """Intercept resolver to analyse permissions"""
         parent_resolver = super(DjangoField, self).get_resolver(parent_resolver)
         if self.permissions:
-            return partial(get_unbound_function(self.permissions_resolver), parent_resolver, self.permissions, None, None, True)
+            return partial(get_unbound_function(self.permissions_resolver), parent_resolver, self.permissions, None,
+                           None, True)
         return parent_resolver

--- a/graphene_django/forms/converter.py
+++ b/graphene_django/forms/converter.py
@@ -86,7 +86,13 @@ def convert_form_field_to_id(field):
     return ID(required=field.required)
 
 
-def convert_form_field_with_choices(name, field):
+def get_form_name(form):
+    """Get form name"""
+    class_name = str(form.__class__).split('.')[-1]
+    return class_name[:-2]
+
+
+def convert_form_field_with_choices(field, name=None, form=None):
     """
     Helper method to convert a field to graphene Field type.
     :param name: form field's name
@@ -96,7 +102,11 @@ def convert_form_field_with_choices(name, field):
     choices = getattr(field, 'choices', None)
 
     if choices:
-        name = to_camel_case(field.label or name)
+        if form:
+            name = to_camel_case("{}_{}".format(get_form_name(form), field.label or name))
+        else:
+            name = field.label or name
+        name = to_camel_case(name.replace(' ', '_'))
         choices = list(get_choices(choices))
         named_choices = [(c[0], c[1]) for c in choices]
         named_choices_descriptions = {c[0]: c[2] for c in choices}

--- a/graphene_django/forms/converter.py
+++ b/graphene_django/forms/converter.py
@@ -97,12 +97,13 @@ def convert_form_field_with_choices(field, name=None, form=None):
     Helper method to convert a field to graphene Field type.
     :param name: form field's name
     :param field: form field to convert to
+    :param form: field's form
     :return: graphene Field
     """
     choices = getattr(field, 'choices', None)
 
     # If is a choice field, but not depends on models
-    if choices and not isinstance(form, (forms.ModelMultipleChoiceField, forms.ModelChoiceField)):
+    if choices and not isinstance(field, (forms.ModelMultipleChoiceField, forms.ModelChoiceField)):
         if form:
             name = to_camel_case("{}_{}".format(get_form_name(form), field.label or name))
         else:

--- a/graphene_django/forms/converter.py
+++ b/graphene_django/forms/converter.py
@@ -101,7 +101,8 @@ def convert_form_field_with_choices(field, name=None, form=None):
     """
     choices = getattr(field, 'choices', None)
 
-    if choices:
+    # If is a choice field, but not depends on models
+    if choices and not isinstance(form, (forms.ModelMultipleChoiceField, forms.ModelChoiceField)):
         if form:
             name = to_camel_case("{}_{}".format(get_form_name(form), field.label or name))
         else:

--- a/graphene_django/forms/mutation.py
+++ b/graphene_django/forms/mutation.py
@@ -13,7 +13,7 @@ from graphene.types.mutation import MutationOptions
 from graphene.types.utils import yank_fields_from_attrs
 from graphene_django.registry import get_global_registry
 
-from .converter import convert_form_field
+from .converter import convert_form_field, convert_form_field_with_choices
 from .types import ErrorType
 
 
@@ -30,11 +30,7 @@ def fields_for_form(form, only_fields, exclude_fields):
         if is_not_in_only or is_excluded:
             continue
 
-        choices = getattr(field, 'choices', None)
-        if choices:
-            fields[name] = convert_form_field(field, field.label or name)
-        else:
-            fields[name] = convert_form_field(field)
+        fields[name] = convert_form_field_with_choices(name, field)
     return fields
 
 

--- a/graphene_django/forms/mutation.py
+++ b/graphene_django/forms/mutation.py
@@ -13,7 +13,7 @@ from graphene.types.mutation import MutationOptions
 from graphene.types.utils import yank_fields_from_attrs
 from graphene_django.registry import get_global_registry
 
-from .converter import convert_form_field, convert_form_field_with_choices
+from .converter import convert_form_field_with_choices
 from .types import ErrorType
 
 

--- a/graphene_django/forms/mutation.py
+++ b/graphene_django/forms/mutation.py
@@ -30,7 +30,7 @@ def fields_for_form(form, only_fields, exclude_fields):
         if is_not_in_only or is_excluded:
             continue
 
-        fields[name] = convert_form_field_with_choices(name, field)
+        fields[name] = convert_form_field_with_choices(field, name=name, form=form)
     return fields
 
 

--- a/graphene_django/forms/mutation.py
+++ b/graphene_django/forms/mutation.py
@@ -30,7 +30,11 @@ def fields_for_form(form, only_fields, exclude_fields):
         if is_not_in_only or is_excluded:
             continue
 
-        fields[name] = convert_form_field(field)
+        choices = getattr(field, 'choices', None)
+        if choices:
+            fields[name] = convert_form_field(field, field.label or name)
+        else:
+            fields[name] = convert_form_field(field)
     return fields
 
 

--- a/graphene_django/forms/tests/test_converter.py
+++ b/graphene_django/forms/tests/test_converter.py
@@ -117,5 +117,5 @@ def test_should_manytoone_convert_connectionorlist():
 
 def test_should_typed_choice_convert_enum():
     field = forms.TypedChoiceField(choices=(('A', 'Choice A'), ('B', 'Choice B')), label='field')
-    graphene_type = convert_form_field_with_choices('field_name', field)
+    graphene_type = convert_form_field_with_choices(field, name='field_name')
     assert isinstance(graphene_type, Enum)

--- a/graphene_django/forms/tests/test_converter.py
+++ b/graphene_django/forms/tests/test_converter.py
@@ -14,6 +14,7 @@ from graphene import (
     DateTime,
     Date,
     Time,
+    Enum,
 )
 
 from ..converter import convert_form_field
@@ -112,3 +113,9 @@ def test_should_manytoone_convert_connectionorlist():
     field = forms.ModelChoiceField(queryset=None)
     graphene_type = convert_form_field(field)
     assert isinstance(graphene_type, ID)
+
+
+def test_should_typed_choice_convert_enum():
+    field = forms.TypedChoiceField(choices=(('A', 'Choice A'), ('B', 'Choice B')))
+    graphene_type = convert_form_field(field, 'field')
+    assert isinstance(graphene_type, Enum)

--- a/graphene_django/forms/tests/test_converter.py
+++ b/graphene_django/forms/tests/test_converter.py
@@ -17,7 +17,7 @@ from graphene import (
     Enum,
 )
 
-from ..converter import convert_form_field
+from ..converter import convert_form_field, convert_form_field_with_choices
 
 
 def assert_conversion(django_field, graphene_field, *args):
@@ -116,6 +116,6 @@ def test_should_manytoone_convert_connectionorlist():
 
 
 def test_should_typed_choice_convert_enum():
-    field = forms.TypedChoiceField(choices=(('A', 'Choice A'), ('B', 'Choice B')))
-    graphene_type = convert_form_field(field, 'field')
+    field = forms.TypedChoiceField(choices=(('A', 'Choice A'), ('B', 'Choice B')), label='field')
+    graphene_type = convert_form_field_with_choices('field_name', field)
     assert isinstance(graphene_type, Enum)


### PR DESCRIPTION
Se añadio a los converters uno para convertir de los choice-fields de los forms a Enum (issue #7)
Dado que los enums debe recibir un _name_, esta propieda se le pasa al converter en el momento de la creacion del campo a traves del metodo `graphene_django.forms.mutation.fields_for_form`
La idea es similar a como se convierten los django-choice, al nombre del campo se le concatena al comienzo el nombre del formulario
- Desventajas: Similar a la conversion de los campos de django, se crea un enum para cada field, aun cuando las opciones (choices) son las mismas.