### PR TITLE
DataLoaderField - A field to dataloading#20

### DIFF
--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -188,7 +188,10 @@ class DataLoaderField(DjangoField):
         # If no resolver is explicitly provided, use dataloader
         self.resolver = self.resolver or self.resolver_data_loader
 
-    def resolver_data_loader(self, root, info, *args):
+    def resolver_data_loader(self, root, info, *args, **kwargs):
         """Resolve field through dataloader"""
-        source_loader = getattr(root, self.source_loader)
+        if root:
+            source_loader = getattr(root, self.source_loader)
+        else:
+            source_loader = kwargs.get(self.source_loader)
         return self.data_loader.load(source_loader)

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -199,4 +199,6 @@ class DataLoaderField(DjangoField):
 
         if self.load_many:
             return self.data_loader.load_many(source_loader)
-        return self.data_loader.load(source_loader)
+        if source_loader:
+            return self.data_loader.load(source_loader)
+        return None

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -171,17 +171,19 @@ class DjangoField(Field):
 
 
 class DataLoaderField(DjangoField):
-    """Class to manage access to dataloader when resolve the field"""
+    """Class to manage access to data-loader when resolve the field"""
 
-    def __init__(self, data_loader, source_loader, type, *args, **kwargs):
+    def __init__(self, type, data_loader, source_loader, load_many=False, *args, **kwargs):
         """
-        Initialization of dataloader to resolve field
-        :param data_loader: dataloader to resolve field
-        :param source_loader:  field to obtain the key for dataloading
+        Initialization of data-loader to resolve field
+        :param data_loader: data-loader to resolve field
+        :param source_loader:  field to obtain the key for data-loading
+        :param load_many: Whether the resolver should try tu obtain one element or multiple elements
         :param kwargs: Extra arguments
         """
         self.data_loader = data_loader
         self.source_loader = source_loader
+        self.load_many = load_many
 
         super(DataLoaderField, self).__init__(type, *args, **kwargs)
 
@@ -191,7 +193,10 @@ class DataLoaderField(DjangoField):
     def resolver_data_loader(self, root, info, *args, **kwargs):
         """Resolve field through dataloader"""
         if root:
-            source_loader = getattr(root, self.source_loader)
+            source_loader = reduce(lambda x, y: getattr(x, y), self.source_loader.split('.'), root)
         else:
             source_loader = kwargs.get(self.source_loader)
+
+        if self.load_many:
+            return self.data_loader.load_many(source_loader)
         return self.data_loader.load(source_loader)

--- a/graphene_django/tests/test_fields.py
+++ b/graphene_django/tests/test_fields.py
@@ -9,6 +9,11 @@ from promise import Promise
 class MyInstance(object):
     value = "value"
     key = 1
+    keys = [1, 2, 3]
+
+    class InnerClass(object):
+        key = 2
+        keys = [4, 5, 6]
 
     def resolver(self):
         return "resolver method"
@@ -61,6 +66,34 @@ class DataLoaderFieldTests(TestCase):
         instance = MyInstance()
 
         self.assertEqual(resolver(instance, None).get(), instance.key)
+
+    def test_dataloaderfield_many(self):
+        MyType = object()
+        data_loader_field = DataLoaderField(data_loader=data_loader, source_loader='keys', type=MyType, load_many=True)
+
+        resolver = data_loader_field.get_resolver(None)
+        instance = MyInstance()
+
+        self.assertEqual(resolver(instance, None).get(), instance.keys)
+
+    def test_dataloaderfield_inner_prop(self):
+        MyType = object()
+        data_loader_field = DataLoaderField(data_loader=data_loader, source_loader='InnerClass.key', type=MyType)
+
+        resolver = data_loader_field.get_resolver(None)
+        instance = MyInstance()
+
+        self.assertEqual(resolver(instance, None).get(), instance.InnerClass.key)
+
+    def test_dataloaderfield_many_inner_prop(self):
+        MyType = object()
+        data_loader_field = DataLoaderField(data_loader=data_loader, source_loader='InnerClass.keys', type=MyType,
+                                            load_many=True)
+
+        resolver = data_loader_field.get_resolver(None)
+        instance = MyInstance()
+
+        self.assertEqual(resolver(instance, None).get(), instance.InnerClass.keys)
 
     def test_dataloaderfield_permissions(self):
         MyType = object()

--- a/graphene_django/tests/test_fields.py
+++ b/graphene_django/tests/test_fields.py
@@ -1,13 +1,24 @@
+from mock import mock
 from unittest import TestCase
 from django.core.exceptions import PermissionDenied
-from graphene_django.fields import DjangoField
+from graphene_django.fields import DjangoField, DataLoaderField
+from promise.dataloader import DataLoader
+from promise import Promise
 
 
 class MyInstance(object):
     value = "value"
+    key = 1
 
     def resolver(self):
         return "resolver method"
+
+
+def batch_load_fn(keys):
+    return Promise.all(keys)
+
+
+data_loader = DataLoader(batch_load_fn=batch_load_fn)
 
 
 class PermissionFieldTests(TestCase):
@@ -21,12 +32,9 @@ class PermissionFieldTests(TestCase):
             def has_perm(self, perm):
                 return perm == 'perm2'
 
-        class Info(object):
-            class Context(object):
-                user = Viewer()
-            context = Context()
+        info = mock.Mock(context=mock.Mock(user=Viewer()))
 
-        self.assertEqual(resolver(MyInstance(), Info()), MyInstance().resolver())
+        self.assertEqual(resolver(MyInstance(), info), MyInstance().resolver())
 
     def test_permission_field_without_permission(self):
         MyType = object()
@@ -37,10 +45,51 @@ class PermissionFieldTests(TestCase):
             def has_perm(self, perm):
                 return False
 
-        class Info(object):
-            class Context(object):
-                user = Viewer()
-            context = Context()
+        info = mock.Mock(context=mock.Mock(user=Viewer()))
 
         with self.assertRaises(PermissionDenied):
-            resolver(MyInstance(), Info())
+            resolver(MyInstance(), info)
+
+
+class DataLoaderFieldTests(TestCase):
+
+    def test_dataloaderfield(self):
+        MyType = object()
+        data_loader_field = DataLoaderField(data_loader=data_loader, source_loader='key', type=MyType)
+
+        resolver = data_loader_field.get_resolver(None)
+        instance = MyInstance()
+
+        self.assertEqual(resolver(instance, None).get(), instance.key)
+
+    def test_dataloaderfield_permissions(self):
+        MyType = object()
+        data_loader_field = DataLoaderField(data_loader=data_loader, source_loader='key', type=MyType,
+                                            permissions=['perm1', 'perm2'])
+
+        resolver = data_loader_field.get_resolver(None)
+        instance = MyInstance()
+
+        class Viewer(object):
+            def has_perm(self, perm):
+                return perm == 'perm2'
+
+        info = mock.Mock(context=mock.Mock(user=Viewer()))
+
+        self.assertEqual(resolver(instance, info).get(), instance.key)
+
+    def test_dataloaderfield_without_permissions(self):
+        MyType = object()
+        data_loader_field = DataLoaderField(data_loader=data_loader, source_loader='key', type=MyType,
+                                            permissions=['perm1', 'perm2'])
+
+        resolver = data_loader_field.get_resolver(None)
+        instance = MyInstance()
+
+        class Viewer(object):
+            def has_perm(self, perm):
+                return False
+
+        info = mock.Mock(context=mock.Mock(user=Viewer()))
+        with self.assertRaises(PermissionDenied):
+            resolver(instance, info)


### PR DESCRIPTION
Se creo el field DataLoaderField para el manejo de campos que pasen por un dataloader. Por ejemplo:

```graphql
class DataLoadedType(graphene.Type):
    pass

class SomeType(graphene.Type):
    data_loaded = DataLoaderField(dataloader, 'source', DataLoadedType)
```

De esta forma, el campo data_loaded de tipo `DataLoadedType` se carga a traves de `dataloader`, pasandole la informacion del atributo `source`.