### PR TITLE
Skip cache in mutations

### DIFF
--- a/graphene_django/forms/mutation.py
+++ b/graphene_django/forms/mutation.py
@@ -61,7 +61,10 @@ class BaseDjangoFormMutation(ClientIDMutation):
         if pk:
             arguments = {"pk": pk}
 
-            if getattr(cls._meta.model, "SKIP_CACHE_MUTATION", True):
+            if getattr(cls._meta.model, "USE_CACHE", False):
+                # If the model uses cache,
+                # then we need to skip loading the intance from cache by passing
+                # __skip_cache as parameter
                 arguments["__skip_cache"] = True
 
             instance = cls._meta.model._default_manager.get(**arguments)

--- a/graphene_django/forms/mutation.py
+++ b/graphene_django/forms/mutation.py
@@ -59,7 +59,12 @@ class BaseDjangoFormMutation(ClientIDMutation):
 
         pk = input.pop("id", None)
         if pk:
-            instance = cls._meta.model._default_manager.get(pk=pk)
+            arguments = {"pk": pk}
+
+            if getattr(cls._meta.model, "SKIP_CACHE_MUTATION", True):
+                arguments["__skip_cache"] = True
+
+            instance = cls._meta.model._default_manager.get(**arguments)
             kwargs["instance"] = instance
 
         return kwargs


### PR DESCRIPTION
<div class="markdown prose w-full break-words dark:prose-invert dark"><p>Se realizaron las siguientes modificaciones en el archivo <code>graphene_django/forms/mutation.py</code>:</p><ol><li><p><strong>Compatibilidad con modelos que usan caché</strong>:</p><ul><li>Se añadió soporte para omitir la carga de instancias desde la caché en modelos que tienen habilitada la opción <code>USE_CACHE</code>.</li><li>Se introdujo una lógica adicional que permite agregar el parámetro <code>__skip_cache</code> al buscar instancias mediante <code>cls._meta.model._default_manager.get</code>.</li></ul></li><li><p><strong>Detalles del cambio</strong>:</p><ul><li>Se verifica si el modelo tiene habilitado el atributo <code>USE_CACHE</code>.</li><li>Si está activo, el diccionario de argumentos incluye el parámetro <code>__skip_cache</code> con un valor de <code>True</code> para garantizar que la instancia se recupere directamente de la base de datos en lugar de la caché.</li></ul></li><li><p><strong>Motivación del cambio</strong>:</p><ul><li>Este ajuste mejora la flexibilidad del manejo de instancias en modelos que emplean caché, evitando posibles inconsistencias o errores derivados de datos en caché no actualizados.</li></ul></li></ol><h3>Impacto:</h3><ul><li>Esta mejora es relevante para proyectos que utilizan modelos con caché en combinación con GraphQL y <code>graphene_django</code>, asegurando un manejo más predecible y controlado de las instancias.</li></ul></div>